### PR TITLE
New feature: Ability to add custom action buttons via the model & Rename view-controller

### DIFF
--- a/src/lib/packages/client/form-builder/src/lib/helper/form.helper.ts
+++ b/src/lib/packages/client/form-builder/src/lib/helper/form.helper.ts
@@ -9,4 +9,11 @@ export class FORM {
   static hasListFilters(obj: any): boolean {
     return "listFilters" in obj;
   }
+
+  static hasListActions(obj: any): boolean {
+    return "listActions" in obj;
+  }
+  static hasDetailActions(obj: any): boolean {
+    return "detailActions" in obj;
+  }
 }

--- a/src/lib/packages/client/list-builder/src/lib/components/base-table-default/base-table-default.component.ts
+++ b/src/lib/packages/client/list-builder/src/lib/components/base-table-default/base-table-default.component.ts
@@ -38,7 +38,7 @@ import {
   BatchWizardComponent,
   CreateWizardComponent,
 } from '../../../../../dynamic-modals';
-import {haslistFields} from "../../helpers/list.helper";
+import {hasListActions, haslistFields} from "../../helpers/list.helper";
 
 @Component({
   template: '<ng-container></ng-container>',
@@ -77,6 +77,7 @@ export class BaseTableDefaultComponent
 
   modelFacade: BaseFacadeType;
   model: any;
+  actions: [] = [];
   modelReference: string;
 
   itemsPerPage = 20;
@@ -150,6 +151,9 @@ export class BaseTableDefaultComponent
       );
     }
 
+    if (hasListActions(this.model)) {
+      this.actions = this.model.listActions();
+    }
     if (this.fields) {
       this.displayedColumns.push('select');
       this.displayedColumns = [...this.displayedColumns, ...this.fields];
@@ -317,6 +321,10 @@ export class BaseTableDefaultComponent
 
   public openExportInsurersModal() {
     this.rowExport.emit();
+  }
+
+  public fireAction(action) {
+    action.click(this.model);
   }
 
   public openAddModal() {

--- a/src/lib/packages/client/list-builder/src/lib/components/table-default/table-default.component.html
+++ b/src/lib/packages/client/list-builder/src/lib/components/table-default/table-default.component.html
@@ -26,6 +26,17 @@
         <!-- Buttons -->
         <ng-container *transloco="let t">
             <div class="flex shrink-0 items-center sm:ml-4 ng-star-inserted my-5">
+                <ng-container *ngFor="let action of actions">
+                    <button
+                            class="ml-4 rounded-md"
+                            mat-flat-button
+                            [color]="'primary'"
+                            (click)="fireAction(action)"
+                    >
+                        <mat-icon [svgIcon]="action.icon"></mat-icon>
+                        <span class="ml-2 mr-1">{{ t(action.label) }}</span>
+                    </button>
+                </ng-container>
                 <button
                         class="ml-4 rounded-md"
                         mat-flat-button

--- a/src/lib/packages/client/list-builder/src/lib/helpers/list.helper.ts
+++ b/src/lib/packages/client/list-builder/src/lib/helpers/list.helper.ts
@@ -14,3 +14,7 @@ export function getFilterOptions(pagination): FilterOptions {
 export function haslistFields(obj: any): boolean {
   return "listFields" in obj;
 }
+
+export function hasListActions(obj: any): boolean {
+  return "listActions" in obj;
+}

--- a/src/lib/packages/types/generics/src/index.ts
+++ b/src/lib/packages/types/generics/src/index.ts
@@ -3,7 +3,7 @@ export * from './lib/helpers/util.helper';
 export * from './lib/types/Constructor';
 export * from './lib/types/BaseFile';
 export * from './lib/types/form-controller';
-export * from './lib/types/view-controller';
+export * from './lib/types/ModelController';
 export * from './lib/types/GenericPagination';
 export * from './lib/types/FilterOptions';
 export * from './lib/types/ScopeFilter';

--- a/src/lib/packages/types/generics/src/lib/types/ModelController.ts
+++ b/src/lib/packages/types/generics/src/lib/types/ModelController.ts
@@ -1,3 +1,4 @@
+import { ActionType } from "../../../../../../../../../next-cms/packages/cms";
 import { DropdownOptions } from "./options/dropdown-options";
 import { ModelRelationOptions } from "./options/relation-options";
 import { ScopeFilter, ScopeFilterTyped } from './ScopeFilter';
@@ -10,7 +11,8 @@ export class ModelController<T> {
 
   $createFields: Fields<T> | Groups<T> | Tabs<T> = [];
   $detailFields: Fields<T> | Groups<T> | Tabs<T> = [];
-  $detailActions: Fields<T>;
+  $detailActions: Fields<T> = [];
+  $listActions: Fields<T> = [];
 
   $listFields: Fields<T> = [];
   $listScope: ScopeFilterTyped<T> = null;
@@ -27,6 +29,10 @@ export class ModelController<T> {
 
   detailActions(): Fields<T> {
     return this.$detailActions;
+  }
+
+  listActions(): Fields<T> {
+    return this.$listActions;
   }
 
   listFields(): Fields<T> {

--- a/src/lib/packages/types/generics/src/lib/types/ModelController.ts
+++ b/src/lib/packages/types/generics/src/lib/types/ModelController.ts
@@ -10,7 +10,7 @@ export class ModelController<T> {
 
   $createFields: Fields<T> | Groups<T> | Tabs<T> = [];
   $detailFields: Fields<T> | Groups<T> | Tabs<T> = [];
-  $detailActions: Array<{ label: string, icon: string, click: () => void }> = [];
+  $detailActions: Fields<T>;
 
   $listFields: Fields<T> = [];
   $listScope: ScopeFilterTyped<T> = null;
@@ -25,7 +25,7 @@ export class ModelController<T> {
     return this.$detailFields;
   }
 
-  detailActions(): Array<{ label: string, icon: string, click: () => void }> {
+  detailActions(): Fields<T> {
     return this.$detailActions;
   }
 

--- a/src/lib/packages/types/generics/src/lib/types/ModelController.ts
+++ b/src/lib/packages/types/generics/src/lib/types/ModelController.ts
@@ -1,22 +1,23 @@
-import {DropdownOptions} from "./options/dropdown-options";
-import {ModelRelationOptions} from "./options/relation-options";
+import { DropdownOptions } from "./options/dropdown-options";
+import { ModelRelationOptions } from "./options/relation-options";
 import { ScopeFilter, ScopeFilterTyped } from './ScopeFilter';
 
 export type Fields<T> = Array<keyof T>;
 export type Groups<T> = Array<{ [key: string]: Fields<T> }>;
 export type Tabs<T> = Array<{ [P in keyof T]?: Fields<T> }>;
 
-export class ModelController<T>{
+export class ModelController<T> {
 
   $createFields: Fields<T> | Groups<T> | Tabs<T> = [];
   $detailFields: Fields<T> | Groups<T> | Tabs<T> = [];
+  $detailActions: Array<{ label: string, icon: string, click: () => void }> = [];
 
   $listFields: Fields<T> = [];
-  $listScope:ScopeFilterTyped<T> = null;
-  $listFilters:ScopeFilterTyped<T>[] = []
+  $listScope: ScopeFilterTyped<T> = null;
+  $listFilters: ScopeFilterTyped<T>[] = []
   $listType: string;
 
-   createFields(): Fields<T> | Groups<T> | Tabs<T> {
+  createFields(): Fields<T> | Groups<T> | Tabs<T> {
     return this.$createFields;
   }
 
@@ -24,11 +25,15 @@ export class ModelController<T>{
     return this.$detailFields;
   }
 
-   listFields(): Fields<T> {
+  detailActions(): Array<{ label: string, icon: string, click: () => void }> {
+    return this.$detailActions;
+  }
+
+  listFields(): Fields<T> {
     return this.$listFields;
   }
 
-   listScope(): ScopeFilterTyped<T> {
+  listScope(): ScopeFilterTyped<T> {
     return this.$listScope;
   }
 

--- a/src/lib/packages/types/generics/src/lib/types/form-controller.ts
+++ b/src/lib/packages/types/generics/src/lib/types/form-controller.ts
@@ -1,3 +1,4 @@
+import { ActionType } from "../../../../../../../../../next-cms/packages/cms";
 import {DropdownOptions} from "./options/dropdown-options";
 import {ModelRelationOptions} from "./options/relation-options";
 
@@ -8,4 +9,6 @@ export interface FormController<T> {
 
   createFields(): Array<{[key: string]: Array<keyof T>}>;
   detailFields?(): Array<{[key: string]: Array<keyof T>}>;
+  detailActions?(): Array<ActionType>;
+  listActions?(): Array<ActionType>;
 }


### PR DESCRIPTION
Added a new feature to add custom action buttons at the top of the detail page and renamed view-controller.ts to ModelController.ts

next-cms pull request: https://github.com/next-levels/next-cms/pull/3